### PR TITLE
Use of generics for better type safety

### DIFF
--- a/api/src/main/java/org/openmrs/module/cpm/ProposedConceptPackage.java
+++ b/api/src/main/java/org/openmrs/module/cpm/ProposedConceptPackage.java
@@ -12,7 +12,7 @@ import org.openmrs.User;
  * are needed, and allowing the proposal reviewer to manage a master/detail style listing of the overall proposal
  * package and its individual concepts.
  */
-public class ProposedConceptPackage extends ShareablePackage {
+public class ProposedConceptPackage extends ShareablePackage<ProposedConcept> {
 
 	private static Log log = LogFactory.getLog(ProposedConceptPackage.class);
 

--- a/api/src/main/java/org/openmrs/module/cpm/ProposedConceptResponsePackage.java
+++ b/api/src/main/java/org/openmrs/module/cpm/ProposedConceptResponsePackage.java
@@ -13,7 +13,7 @@ import org.openmrs.User;
  * are needed, and allowing the proposal reviewer to manage a master/detail style listing of the overall proposal
  * package and its individual concepts.
  */
-public class ProposedConceptResponsePackage extends ShareablePackage {
+public class ProposedConceptResponsePackage extends ShareablePackage<ProposedConceptResponse> {
 	
 	private static Log log = LogFactory.getLog(ProposedConceptResponsePackage.class);
 
@@ -40,7 +40,7 @@ public class ProposedConceptResponsePackage extends ShareablePackage {
 	 * @param shareablePackage The Concept Proposal Package submitted by a client side proposer
 	 */
 	
-	public ProposedConceptResponsePackage(final ShareablePackage shareablePackage) {
+	public ProposedConceptResponsePackage(final ProposedConceptPackage shareablePackage) {
 		super();
 		log.debug("Creating a ProposedConceptResponsePackage from: " + shareablePackage);
 
@@ -48,13 +48,13 @@ public class ProposedConceptResponsePackage extends ShareablePackage {
 		this.setEmail(shareablePackage.getEmail());
 		this.setDescription(shareablePackage.getDescription());
 		this.setProposedConceptPackageUuid(shareablePackage.getUuid());
-		this.setProposedConcepts(new HashSet<ShareableProposal>());
+		this.setProposedConcepts(new HashSet<ProposedConceptResponse>());
 		
 		if (shareablePackage.getProposedConcepts() != null) {
 			// For each of the proposals in the submitted ProposedConceptPackage we create and equivalent 
 			// response item that will allow us to record additional details
 			
-			for (ShareableProposal currentProposal : shareablePackage.getProposedConcepts()) {
+			for (ProposedConcept currentProposal : shareablePackage.getProposedConcepts()) {
 				ProposedConceptResponse proposalResponse  = new ProposedConceptResponse(currentProposal);
 				this.addProposedConcept(proposalResponse);
 			}

--- a/api/src/main/java/org/openmrs/module/cpm/ShareablePackage.java
+++ b/api/src/main/java/org/openmrs/module/cpm/ShareablePackage.java
@@ -12,14 +12,14 @@ import org.openmrs.BaseOpenmrsObject;
  * between a Concept proposer, and a Concept Proposal reviewer. The attributes modelled in the
  * abstract class are the ones that will be exchanged between the two using transfer REST services
  */
-public abstract class ShareablePackage extends BaseOpenmrsObject {
+public abstract class ShareablePackage<P extends ShareableProposal> extends BaseOpenmrsObject {
 	
 	protected Log log = LogFactory.getLog(getClass());
 	
 	private String name;
 	private String email;
 	private String description;
-	private Set<ShareableProposal> proposedConcepts = new HashSet<ShareableProposal>();
+	private Set<P> proposedConcepts = new HashSet<P>();
 	private PackageStatus status = PackageStatus.DRAFT;
 	
 	public ShareablePackage() {
@@ -50,11 +50,11 @@ public abstract class ShareablePackage extends BaseOpenmrsObject {
 		this.description = description;
 	}
 	
-	public Set<ShareableProposal> getProposedConcepts() {
+	public Set<P> getProposedConcepts() {
 		return proposedConcepts;
 	}
 	
-	public void setProposedConcepts(Set<ShareableProposal> proposedConcepts) {
+	public void setProposedConcepts(Set<P> proposedConcepts) {
 		this.proposedConcepts = proposedConcepts;
 	}
 	
@@ -70,7 +70,7 @@ public abstract class ShareablePackage extends BaseOpenmrsObject {
 	 * Utility methods
 	 */
 	
-	public void addProposedConcept(final ShareableProposal proposedConcept) {
+	public void addProposedConcept(final P proposedConcept) {
 		if (proposedConcept == null) {
 			log.warn("Ignoring request to add null concept");
 			return;
@@ -84,7 +84,7 @@ public abstract class ShareablePackage extends BaseOpenmrsObject {
 		}
 	}
 	
-	public void removeProposedConcept(final ShareableProposal proposedConcept) {
+	public void removeProposedConcept(final P proposedConcept) {
 		if (proposedConcept == null) {
 			log.warn("Ignoring request to remove null concept");
 			return;


### PR DESCRIPTION
I've taken the liberty of modifying flashard's models to make use of generics to enforce stricter type safety by adding type parameters to ShareablePackage.  Any subclass of ShareablePackage must declare the type of ShareableProposal that it uses.

Benefits include:
- Type safety: It will be impossible to add a ProposedConceptResponse to a ProposedConceptPackage
- Easier API to work with - no longer necessary to cast from ShareableProposal
