### PR TITLE
fix menu service filename case issue

### DIFF
--- a/omod/src/main/webapp/resources/js/cpm-impl.js
+++ b/omod/src/main/webapp/resources/js/cpm-impl.js
@@ -11,6 +11,6 @@ define([
 	'js/directives/cpmMenu',
 	'js/directives/jqueryUiDialog',
 	'js/filters/proposalStatus',
-	'js/services/Menu',
+	'js/services/menu',
 	'js/services/services'
 ], function () {});

--- a/omod/src/main/webapp/resources/js/cpmr-impl.js
+++ b/omod/src/main/webapp/resources/js/cpmr-impl.js
@@ -11,6 +11,6 @@ define([
 	'js/directives/cpmMenu',
 	'js/directives/jqueryUiDialog',
 	'js/filters/proposalReviewStatus',
-	'js/services/Menu',
+	'js/services/menu',
 	'js/services/services'
 ], function () {});


### PR DESCRIPTION
The functional tests are failing in the CI environment due to incorrect casing of the new menu service
