### PR TITLE
JS unit tests for Menu.getMenu called from controllers

### DIFF
--- a/omod/src/test/webapp/unit/controllers/EditProposalCtrlSpec.js
+++ b/omod/src/test/webapp/unit/controllers/EditProposalCtrlSpec.js
@@ -13,16 +13,30 @@ define([
     var routeParams;
     var controller;
     var alertsService;
+    var menuService;
 
     beforeEach(module('cpm.controllers'));
 
-    beforeEach(inject(function($rootScope, $controller, $httpBackend, Alerts) {
+    beforeEach(inject(function($rootScope, $controller, $httpBackend, Alerts, Menu) {
       scope = $rootScope.$new();
       httpBackend = $httpBackend;
       controller = $controller;
       alertsService = Alerts;
+      menuService = Menu;
     }));
 
+
+    it('should get menu', function () {
+      var menuResponse = 'something';
+      spyOn(menuService, 'getMenu').andCallFake(function (index) {
+        expect(index).toBe(1);
+        return menuResponse;
+      });
+      
+      controller('EditProposalCtrl', {$scope: scope, $routeParams: {}});
+
+      expect(scope.menu).toBe(menuResponse);
+    });
 
     it('should not fetch anything and set the mode to create and initialise the status to \'DRAFT\' when not given a proposal id', function() {
       routeParams = {};

--- a/omod/src/test/webapp/unit/controllers/ListIncomingProposalsCtrlSpec.js
+++ b/omod/src/test/webapp/unit/controllers/ListIncomingProposalsCtrlSpec.js
@@ -1,0 +1,34 @@
+define(['angular-mocks', 'js/controllers/ListIncomingProposalsCtrl'], function() {
+  'use strict';
+
+  describe("ListIncomingProposals Controller Spec", function() {
+
+    var scope;
+    var httpBackend;
+    var controller;
+    var menuService;
+
+    beforeEach(module('cpm.controllers'));
+
+    beforeEach(inject(function($rootScope, $controller, $httpBackend, Menu) {
+      scope = $rootScope.$new();
+      controller = $controller;
+      httpBackend = $httpBackend;
+      menuService = Menu;
+    }));
+
+    it('should get menu', function () {
+      httpBackend.expectGET('/openmrs/ws/cpm/proposalReviews').respond({});
+      var menuResponse = 'something';
+      spyOn(menuService, 'getMenu').andCallFake(function (index) {
+        expect(index).toBe(3);
+        return menuResponse;
+      });
+      
+      controller('ListIncomingProposalsCtrl', {$scope: scope, $routeParams: {}});
+
+      expect(scope.menu).toBe(menuResponse);
+    });
+
+  });
+});

--- a/omod/src/test/webapp/unit/controllers/ListProposalsCtrlSpec.js
+++ b/omod/src/test/webapp/unit/controllers/ListProposalsCtrlSpec.js
@@ -6,17 +6,34 @@ define(['angular-mocks', 'js/controllers/ListProposalsCtrl'], function() {
     var scope;
     var httpBackend;
     var controller;
+    var menuService;
 
     beforeEach(module('cpm.controllers'));
 
-    beforeEach(inject(function($rootScope, $controller, $httpBackend) {
+    beforeEach(inject(function($rootScope, $controller, $httpBackend, Menu) {
       scope = $rootScope.$new();
       controller = $controller;
       httpBackend = $httpBackend;
+      menuService = Menu;
     }));
 
+    beforeEach(function () {
+      httpBackend.whenGET('/openmrs/ws/cpm/proposals').respond([]);
+    });
+
+    it('should get menu', function () {
+      var menuResponse = 'something';
+      spyOn(menuService, 'getMenu').andCallFake(function (index) {
+        expect(index).toBe(2);
+        return menuResponse;
+      });
+      
+      controller('ListProposalsCtrl', {$scope: scope, $routeParams: {}});
+
+      expect(scope.menu).toBe(menuResponse);
+    });
+
     it("should have reponseReceived initialised to false", function() {
-      httpBackend.expectGET('/openmrs/ws/cpm/proposals').respond([]);
       controller('ListProposalsCtrl', {$scope: scope});
       // no flush
 

--- a/omod/src/test/webapp/unit/controllers/ReviewConceptCtrlSpec.js
+++ b/omod/src/test/webapp/unit/controllers/ReviewConceptCtrlSpec.js
@@ -6,15 +6,29 @@ define(['angular-mocks', 'js/controllers/ReviewConceptCtrl'], function() {
     var scope;
     var httpBackend;
     var controller;
+    var menuService;
 
     beforeEach(module('cpm.controllers'));
 
-    beforeEach(inject(function($rootScope, $controller, $httpBackend) {
+    beforeEach(inject(function($rootScope, $controller, $httpBackend, Menu) {
       scope = $rootScope.$new();
       httpBackend = $httpBackend;
       controller = $controller;
+      menuService = Menu;
     }));
 
+    it('should get menu', function () {
+      httpBackend.whenGET('/openmrs/ws/cpm/proposalReviews/1/concepts/1').respond({});
+      var menuResponse = 'something';
+      spyOn(menuService, 'getMenu').andCallFake(function (index) {
+        expect(index).not.toBeDefined();
+        return menuResponse;
+      });
+      
+      controller('ReviewConceptCtrl', {$scope: scope, $routeParams: {proposalId: 1, conceptId: 1}});
+
+      expect(scope.menu).toBe(menuResponse);
+    });
 
     it("should fetch a comment from a supplied concept review", function() {
       httpBackend.expectGET('/openmrs/ws/cpm/proposalReviews/1/concepts/1').respond({

--- a/omod/src/test/webapp/unit/controllers/ReviewProposalCtrlSpec.js
+++ b/omod/src/test/webapp/unit/controllers/ReviewProposalCtrlSpec.js
@@ -1,0 +1,35 @@
+define(['angular-mocks', 'js/controllers/ReviewProposalCtrl'], function() {
+  'use strict';
+
+  describe("ReviewProposalCtrl Controller Spec", function() {
+
+    var scope;
+    var httpBackend;
+    var controller;
+    var menuService;
+
+    beforeEach(function () {
+      module('cpm.controllers')
+      inject(function($rootScope, $controller, $httpBackend, Menu) {
+        scope = $rootScope.$new();
+        controller = $controller;
+        httpBackend = $httpBackend;
+        menuService = Menu;
+      });
+      httpBackend.whenGET('/openmrs/ws/cpm/proposalReviews').respond({});
+    });
+
+    it('should get menu', function () {
+      var menuResponse = 'something';
+      spyOn(menuService, 'getMenu').andCallFake(function (index) {
+        expect(index).not.toBeDefined();
+        return menuResponse;
+      });
+      
+      controller('ReviewProposalCtrl', {$scope: scope, $routeParams: {}});
+
+      expect(scope.menu).toBe(menuResponse);
+    });
+
+  });
+});

--- a/omod/src/test/webapp/unit/controllers/SettingsCtrlSpec.js
+++ b/omod/src/test/webapp/unit/controllers/SettingsCtrlSpec.js
@@ -1,0 +1,35 @@
+define(['angular-mocks', 'js/controllers/SettingsCtrl'], function() {
+  'use strict';
+
+  describe("SettingsCtrl", function() {
+
+    var scope;
+    var httpBackend;
+    var controller;
+    var menuService;
+
+    beforeEach(function () {
+      module('cpm.controllers');
+      inject(function($rootScope, $controller, $httpBackend, Menu) {
+        scope = $rootScope.$new();
+        controller = $controller;
+        httpBackend = $httpBackend;
+        menuService = Menu;
+      });
+      httpBackend.whenGET('/openmrs/ws/cpm/settings').respond({});
+    });
+
+    it('should get menu', function () {
+      var menuResponse = 'something';
+      spyOn(menuService, 'getMenu').andCallFake(function (index) {
+        expect(index).toBe(4);
+        return menuResponse;
+      });
+      
+      controller('SettingsCtrl', {$scope: scope, $routeParams: {}});
+
+      expect(scope.menu).toBe(menuResponse);
+    });
+
+  });
+});


### PR DESCRIPTION
Looks like something was wrong with my fork. Just recreated it and applied changes again.

There was a problem with the build recently where MenuService was referenced, but there was only a provider for Menu. These tests make sure that Menu.getMenu is called from controllers so it does not happen again.

This commit is only adding tests for previous commit (467b5a0483e49fb572dd3a76d2b3446d0b6f9bcb)
