### PR TITLE
ignore new build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,12 @@
 # Maven build directories
 target
 
+#Gradle build directories
+.gradle
+build
+api/build
+omod/build
+
 # IntelliJ project files
 .idea
 *.iml


### PR DESCRIPTION
looks like gradle build outputs to new directories, which should be excluded from source control
