### PR TITLE
Changing description fields to TEXT

### DIFF
--- a/conceptpropose/api/src/main/resources/liquibase.xml
+++ b/conceptpropose/api/src/main/resources/liquibase.xml
@@ -68,5 +68,9 @@
         </createTable>
 
 	</changeSet>
+    
+    <changeSet id="conceptpropose_20140513" author="OpenMRS-Australia">
+        <modifyDataType tableName="conceptpropose_proposed_concept_package" columnName="description" newDataType="TEXT"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/conceptreview/api/src/main/resources/liquibase.xml
+++ b/conceptreview/api/src/main/resources/liquibase.xml
@@ -140,4 +140,8 @@
 
     </changeSet>
 
+    <changeSet id="conceptreview_20140513" author="OpenMRS-Australia">
+        <modifyDataType tableName="conceptreview_proposed_concept_review_package" columnName="description" newDataType="TEXT"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Fixing bug where large amounts of text in description overfilled database field (previously 1000 char limit)
