### PR TITLE
Update package status if sufficient concepts have been processed

### DIFF
--- a/conceptreview/api/src/main/java/org/openmrs/module/conceptreview/api/db/hibernate/HibernateProposedConceptPackageReviewDAO.java
+++ b/conceptreview/api/src/main/java/org/openmrs/module/conceptreview/api/db/hibernate/HibernateProposedConceptPackageReviewDAO.java
@@ -66,27 +66,15 @@ public class HibernateProposedConceptPackageReviewDAO implements ProposedConcept
 	public ProposedConceptReviewPackage saveConceptProposalReviewPackage(ProposedConceptReviewPackage conceptPackageReview) {
 		if (conceptPackageReview != null) {
 			boolean hasUnprocessedConcepted = false;
-			boolean hasRejectedConcepted = false;
 			if(conceptPackageReview.getProposedConcepts() != null && conceptPackageReview.getStatus() != null)
 			{
 				for (final ProposedConceptReview conceptProposal : conceptPackageReview.getProposedConcepts()) {
-					if(conceptProposal.getStatus() == ProposalStatus.CLOSED_REJECTED)
-						hasRejectedConcepted = true;
-					else if(conceptProposal.getStatus() == ProposalStatus.RECEIVED)
+					if(conceptProposal.getStatus() == ProposalStatus.RECEIVED) {
 						hasUnprocessedConcepted = true;
+					}
 				}
-				if(hasUnprocessedConcepted)
-				{
-					if(hasRejectedConcepted)
-						conceptPackageReview.setStatus(PackageStatus.CLOSED);
-					else
-						conceptPackageReview.setStatus(PackageStatus.RECEIVED);
-				}
-				else
-					conceptPackageReview.setStatus(PackageStatus.CLOSED);
+				conceptPackageReview.setStatus(hasUnprocessedConcepted ? PackageStatus.RECEIVED : PackageStatus.CLOSED);
 			}
-
-
 			sessionFactory.getCurrentSession().saveOrUpdate(conceptPackageReview);
 			return conceptPackageReview;
 		} else {

--- a/conceptreview/api/src/test/java/org/openmrs/module/conceptreview/api/TestProposedConceptReviewService.java
+++ b/conceptreview/api/src/test/java/org/openmrs/module/conceptreview/api/TestProposedConceptReviewService.java
@@ -297,7 +297,7 @@ public class TestProposedConceptReviewService extends BaseModuleContextSensitive
         service.saveProposedConceptReviewPackage(testPackage);
     }
 	@Test
-	public void saveProposedConceptPackageReview_anUnprocessedConceptsShouldLeavePackageAsIncompleted() {
+	public void saveProposedConceptPackageReview_anUnprocessedConceptShouldLeavePackageAsIncompleted() {
 		ProposedConceptReviewPackage testPackage = getMockProposedConceptPackageReview(null, "new package");
 
 		ProposedConceptReview conceptReview = getMockProposedConceptReview();
@@ -313,7 +313,7 @@ public class TestProposedConceptReviewService extends BaseModuleContextSensitive
 		assertThat(retrievedPackage.getStatus(), is(equalTo(PackageStatus.RECEIVED)));
 	}
 	@Test
-	public void saveProposedConceptPackageReview_unprocessedConceptsWithNoRejectionsShouldLeavePackageAsIncompleted() {
+	public void saveProposedConceptPackageReview_unprocessedConceptsShouldLeavePackageAsIncompleted() {
 		ProposedConceptReviewPackage testPackage = getMockProposedConceptPackageReview(null, "new package");
 
 		ProposedConceptReview conceptReview = getMockProposedConceptReview();
@@ -333,27 +333,7 @@ public class TestProposedConceptReviewService extends BaseModuleContextSensitive
 		assertThat(retrievedPackage.getStatus(), is(equalTo(PackageStatus.RECEIVED)));
 	}
 	@Test
-	public void saveProposedConceptPackageReview_aRejectedConceptsShouldMarkPackageAsCompleted() {
-		ProposedConceptReviewPackage testPackage = getMockProposedConceptPackageReview(null, "new package");
-
-		ProposedConceptReview conceptReview = getMockProposedConceptReview();
-		conceptReview.setStatus(ProposalStatus.RECEIVED);
-		testPackage.addProposedConcept(conceptReview);
-
-		ProposedConceptReview conceptReview2 = getMockProposedConceptReview();
-		conceptReview2.setStatus(ProposalStatus.CLOSED_REJECTED);
-		testPackage.addProposedConcept(conceptReview2);
-
-		testPackage.setStatus(PackageStatus.RECEIVED);
-		log.info("Before: " + testPackage);
-
-		service.saveProposedConceptReviewPackage(testPackage);
-		final ProposedConceptReviewPackage retrievedPackage = service.getProposedConceptReviewPackageById(testPackage.getId());
-
-		assertThat(retrievedPackage.getStatus(), is(equalTo(PackageStatus.CLOSED)));
-	}
-	@Test
-	public void saveProposedConceptPackageReview_aProcessedConceptsShouldMarkPackageAsCompleted() {
+	public void saveProposedConceptPackageReview_aProcessedConceptShouldMarkPackageAsCompleted() {
 		ProposedConceptReviewPackage testPackage = getMockProposedConceptPackageReview(null, "new package");
 
 		ProposedConceptReview conceptReview = getMockProposedConceptReview();


### PR DESCRIPTION
Will update package status to closed if
- any concept has been rejected
- all concepts have been processed (existing / created new / rejected)
