### PR TITLE
Update to select concept properly

### DIFF
--- a/conceptreview/omod/src/main/webapp/resources/partials/SearchConceptDialog.html
+++ b/conceptreview/omod/src/main/webapp/resources/partials/SearchConceptDialog.html
@@ -16,7 +16,7 @@
                 <tr ng-repeat="concept in concepts | filter:searchTerm" ng-click="conceptClicked(concept)">
                     <td ng-switch="isMultiple">
                         <input ng-switch-when="true" type="checkbox" ng-click="$event.stopPropagation()" ng-model="concept.selected"/>
-                        <input ng-switch-when="false" type="radio" ng-click="$event.stopPropagation()" ng-model="selectedConcept" name="concept" ng-value="concept"/>
+                        <input ng-switch-when="false" type="radio" ng-model="selectedConcept" name="concept" ng-value="concept"/>
                     </td>
                     <td>{{concept.preferredName}}</td>
                     <td>{{concept.synonyms}}</td>

--- a/functional-tests/src/test/java/org/openmrs/module/conceptpropose/pagemodel/QueryBrowserPage.java
+++ b/functional-tests/src/test/java/org/openmrs/module/conceptpropose/pagemodel/QueryBrowserPage.java
@@ -5,20 +5,26 @@ import org.openmrs.module.conceptpropose.functionaltest.steps.SeleniumDriver;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 public class QueryBrowserPage {
 
 	private final String queryBrowserPageUrl;
 	private WebDriver driver;
 	private String openmrsUrl;
+	public static final int DEFAULT_TIMEOUT_IN_SECONDS = 10;
+	protected WebDriverWait defaultWait;
 
 	public QueryBrowserPage() throws IOException {
 		this.driver = SeleniumDriver.getDriver(); // request current driver every time new page constructed
+		this.driver.manage().timeouts().implicitlyWait(DEFAULT_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
+		defaultWait = new WebDriverWait(driver, DEFAULT_TIMEOUT_IN_SECONDS);
 
 		if (StringUtils.isNotBlank(System.getenv("openmrs_username"))) {
 //			username = System.getenv("openmrs_username");

--- a/functional-tests/src/test/java/org/openmrs/module/conceptreview/functionaltest/steps/ReviewProposalStepDefs.java
+++ b/functional-tests/src/test/java/org/openmrs/module/conceptreview/functionaltest/steps/ReviewProposalStepDefs.java
@@ -62,6 +62,8 @@ public class ReviewProposalStepDefs {
     public void I_mark_a_concept_as_accepted_rejected_or(String arg1) {
         reviewConceptPage = reviewProposalPage.navigateTo(1);
         reviewConceptPage.rejectConcept();
+
+        // was getting weird errors? can't save WARN - DispatcherServlet.noHandlerFound(947) |2014-10-25 03:42:45,918| No mapping found for HTTP request with URI [/openmrs/ws/conceptreview/proposalReviews/1/concepts] in DispatcherServlet with name 'openmrs'
         reviewConceptPage = reviewProposalPage.navigateTo(2);
         reviewConceptPage.acceptConcept();
         reviewConceptPage = reviewProposalPage.navigateTo(3);

--- a/functional-tests/src/test/java/org/openmrs/module/conceptreview/pagemodel/QueryBrowserPage.java
+++ b/functional-tests/src/test/java/org/openmrs/module/conceptreview/pagemodel/QueryBrowserPage.java
@@ -5,11 +5,13 @@ import org.openmrs.module.conceptreview.functionaltest.steps.SeleniumDriver;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 // TODO - refactor Login , SeleniumDriver and QueryBrowserPage to common package? tried to do so but IntelliJ wasn't able to run the review functional tests correctly
 public class QueryBrowserPage {
@@ -17,10 +19,13 @@ public class QueryBrowserPage {
 	private final String queryBrowserPageUrl;
 	private WebDriver driver;
 	private String openmrsUrl;
+	public static final int DEFAULT_TIMEOUT_IN_SECONDS = 10;
+	protected WebDriverWait defaultWait;
 
-	public QueryBrowserPage() throws IOException {
+    public QueryBrowserPage() throws IOException {
 		this.driver = SeleniumDriver.getDriver(); // request current driver every time new page constructed
-
+		this.driver.manage().timeouts().implicitlyWait(DEFAULT_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
+		defaultWait = new WebDriverWait(driver, DEFAULT_TIMEOUT_IN_SECONDS);
 		if (StringUtils.isNotBlank(System.getenv("openmrs_username"))) {
 //			username = System.getenv("openmrs_username");
 //			password = System.getenv("openmrs_password");

--- a/functional-tests/src/test/java/org/openmrs/module/conceptreview/pagemodel/ReviewConceptPage.java
+++ b/functional-tests/src/test/java/org/openmrs/module/conceptreview/pagemodel/ReviewConceptPage.java
@@ -6,6 +6,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 
+import java.util.List;
+
 public class ReviewConceptPage extends BaseCpmPage {
 
     public ReviewConceptPage(WebDriver driver) {
@@ -14,6 +16,7 @@ public class ReviewConceptPage extends BaseCpmPage {
 
     public ReviewProposalPage acceptConcept(){
         getElementByAttribute("button","ng-click", "conceptCreated()").click();
+        enterNewConcept("ba",1);
         return new ReviewProposalPage(driver);
     }
     public ReviewProposalPage rejectConcept(){
@@ -22,7 +25,39 @@ public class ReviewConceptPage extends BaseCpmPage {
     }
     public ReviewProposalPage markConceptAsExisted(){
         getElementByAttribute("button","ng-click", "conceptExists()").click();
+        enterNewConcept("ba", 1);
         return new ReviewProposalPage(driver);
+    }
+    public WebElement findVisibleElement(WebDriver driver, By by)
+    {
+        List<WebElement> elements = driver.findElements(by);
+        for(WebElement element :elements) {
+            if(element.isDisplayed())
+                return element;
+        }
+        return null;
+    }
+    public void enterNewConcept(String conceptToSearch, int numberToAdd) {
+        // if multiple concepts are processed at one go, there will be multiple concept search boxes
+        // so just use the visible one
+        final WebElement addConceptContainer = findVisibleElement(driver, By.cssSelector(".resultsContainer"));
+        final WebElement searchBox = findVisibleElement(driver, By.className("searchBox"));
+        searchBox.sendKeys(conceptToSearch);
+
+        WebElement conceptListTable = addConceptContainer.findElement(By.className("conceptList"));
+        List<WebElement> resultRowsElement = conceptListTable.findElements(By.tagName("tr"));
+        int changed = 0;
+        for(int i = 0; i < resultRowsElement.size(); i++){
+            WebElement row =  resultRowsElement.get(i);
+            row.findElements(By.tagName("input")).get(0).click();
+            changed++;
+            if(changed >= numberToAdd){
+                break;
+            }
+        }
+        WebElement footer = findVisibleElement(driver, (By.className("dialogFooter")));
+        WebElement addConceptButton = getElementByAttribute(footer, "button", "ng-click", "add()");
+        addConceptButton.click();
     }
 	private WebElement getAddCommentButton()
 	{

--- a/functional-tests/src/test/java/org/openmrs/module/conceptreview/pagemodel/ReviewProposalPage.java
+++ b/functional-tests/src/test/java/org/openmrs/module/conceptreview/pagemodel/ReviewProposalPage.java
@@ -26,7 +26,7 @@ public class ReviewProposalPage extends BaseCpmPage {
 		return concepts;
 	}
     public ReviewConceptPage navigateTo(int conceptNumber) {
-        driver.findElement(By.cssSelector("#conceptreview .results tr:nth-of-type(" + String.valueOf(conceptNumber) + ")")).click();
+        driver.findElement(By.cssSelector("#conceptreview .results > tr:nth-of-type(" + String.valueOf(conceptNumber) + ")")).click();
         return new ReviewConceptPage(driver);
     }
 


### PR DESCRIPTION
Updated with 
- implicit waits on Query Browser
- removing $event.stopPropagation that prevent concept from being selected when the input radio box (not the row) was clicked
- selecting concept when deciding that concept is newly created / existing
